### PR TITLE
Add wake and sleep commands

### DIFF
--- a/adafruit_ssd1322.py
+++ b/adafruit_ssd1322.py
@@ -93,3 +93,31 @@ class SSD1322(displayio.Display):
             reverse_pixels_in_byte=True,
             bytes_per_cell=2,
         )
+        self._is_awake = True  # Display starts in active state (_INIT_SEQUENCE)
+
+    @property
+    def is_awake(self):
+        """
+        The power state of the display. (read-only)
+        `True` if the display is active, `False` if in sleep mode.
+        :type: bool
+        """
+        return self._is_awake
+
+    def sleep(self):
+        """
+        Put display into sleep mode.
+        Display uses < 10uA in sleep mode. Display remembers display data and operation mode
+        active prior to sleeping. MP can access (update) the built-in display RAM.
+        """
+        if self._is_awake:
+            self.bus.send(int(0xAE), "")  # 0xAE = display off, sleep mode
+            self._is_awake = False
+
+    def wake(self):
+        """
+        Wake display from sleep mode
+        """
+        if not self._is_awake:
+            self.bus.send(int(0xAF), "")  # 0xAF = display on
+            self._is_awake = True


### PR DESCRIPTION
Inspired from : 
- [Adafruit_CircuitPython_DisplayIO_SSD1306](https://github.com/adafruit/Adafruit_CircuitPython_DisplayIO_SSD1306/blob/87877c28b4d286d2af86b2611d4efaa2087c6078/adafruit_displayio_ssd1306.py#L100)
- [Luma.oled](https://github.com/rm-hull/luma.oled/blob/5cbac38eaa3d7b06cf97f24d76877693c72d3233/luma/oled/device/__init__.py#L425) & [Luma.core](https://github.com/rm-hull/luma.core/blob/0b33e512a4ef8c7ae91ccd019bbe9fec0fbdcac6/luma/core/const.py#L7)
- [NHD-3.12-25664UC_Example](https://github.com/NewhavenDisplay/NHD-3.12-25664UC_Example/blob/67cf301ba60840bee816bf408e5db5717184da6f/NHD-3.12-25664UC/NHD-3.12-25664UC.ino#L293)

Tested on a 256x64 SSD1322 display with QT Py RP2040

Fix #14 