### PR TITLE
Change data param to bytes

### DIFF
--- a/adafruit_ssd1322.py
+++ b/adafruit_ssd1322.py
@@ -111,7 +111,7 @@ class SSD1322(displayio.Display):
         active prior to sleeping. MP can access (update) the built-in display RAM.
         """
         if self._is_awake:
-            self.bus.send(int(0xAE), "")  # 0xAE = display off, sleep mode
+            self.bus.send(int(0xAE), b"")  # 0xAE = display off, sleep mode
             self._is_awake = False
 
     def wake(self):
@@ -119,5 +119,5 @@ class SSD1322(displayio.Display):
         Wake display from sleep mode
         """
         if not self._is_awake:
-            self.bus.send(int(0xAF), "")  # 0xAF = display on
+            self.bus.send(int(0xAF), b"")  # 0xAF = display on
             self._is_awake = True

--- a/adafruit_ssd1322.py
+++ b/adafruit_ssd1322.py
@@ -111,7 +111,7 @@ class SSD1322(displayio.Display):
         active prior to sleeping. MP can access (update) the built-in display RAM.
         """
         if self._is_awake:
-            self.bus.send(int(0xAE), b"")  # 0xAE = display off, sleep mode
+            self.bus.send(0xAE, b"")  # 0xAE = display off, sleep mode
             self._is_awake = False
 
     def wake(self):
@@ -119,5 +119,5 @@ class SSD1322(displayio.Display):
         Wake display from sleep mode
         """
         if not self._is_awake:
-            self.bus.send(int(0xAF), b"")  # 0xAF = display on
+            self.bus.send(0xAF, b"")  # 0xAF = display on
             self._is_awake = True


### PR DESCRIPTION
Follow up to our conversation earlier, here's what an example fix would look like in changing the relevant libraries.  I guess this is a competing change to https://github.com/adafruit/circuitpython/pull/6151 so I'm tagging that.  As far as I could tell in the libraries, turning displays on/off seems to be the only time `str` was used, but I can double check that.  Just wanted that conversation captured.  I can happily close either this or the mentioned PR depending on the route to take, or some other third option.